### PR TITLE
fix: rm isolated var.get.nc call in .resource_time

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -279,8 +279,6 @@ try_att <- function(nc, variable, attribute) {
   
   T_var_info <- var.inq.nc(nc, T_name)
   
-  var.get.nc(nc, "time")
-  
   time_steps <- utcal.nc(
     unitstring = att.get.nc(nc, T_var_info$name, "units"),
     value = var.get.nc(nc, T_var_info$name, unpack = TRUE),


### PR DESCRIPTION
In `R/utils.R:282` there is an isolated call to `var.get.nc` that is not being used. It has a hard-coded parameter to get the "time" variable from `nc`, but this fails in the case of resources without a "time" variable (i.e. PRISM). 😄

It was added in 6261e3bbd65f1fd07bb5c8474a185b10cd0e124a.